### PR TITLE
kara-memo dispatch + cache strategy rewrite

### DIFF
--- a/programs/arithmetic-2026-cross-memo/pseudocode.md
+++ b/programs/arithmetic-2026-cross-memo/pseudocode.md
@@ -1,0 +1,145 @@
+# Cross-Memo Pseudocode
+
+The algorithm the model is being asked to simulate, in plain pseudocode.
+The actual trace it emits is a deterministic line-by-line transcript of
+this execution — every named value below appears verbatim as a tape token.
+
+## Setup
+
+```
+CHUNK         := 2                          # base-10^CHUNK cell size
+BASE          := 10^CHUNK                   # 100 when CHUNK=2
+REFRESH_EVERY := 8                          # tick cycle length
+
+A := split(operand_a, CHUNK)                # LSB-first cells, A[0] is least-significant
+B := split(operand_b, CHUNK)
+N := len(A)
+M := len(B)
+out   := []
+carry := 0
+```
+
+## Outer loop — one output cell per k
+
+```
+for k in 0 .. N+M-2:
+
+    tick := k mod REFRESH_EVERY
+
+    # Attention-maintenance: re-print operand tapes every REFRESH_EVERY
+    # iterations so the model never has to attend back more than ~8 k-blocks
+    # to find a cell value.
+    if tick == 0:
+        emit "tick={tick} [FIRE]"
+        emit "REFRESH"
+        emit tape(A, prefix="A")             # multi-line if >8 cells
+        emit tape(B, prefix="B")
+        emit "END_REFRESH"
+    else:
+        emit "tick={tick} [SKIP]"
+
+    emit "k={k}"
+
+    # Diagonal of the convolution at index k
+    pairs := [ (i, k-i) for i in max(0, k-(M-1)) .. min(N-1, k) ]
+
+    # Pair-grouped accumulation. Every line shows two products and the
+    # running sum update, so the model only needs to attend 1 line back.
+    sum := 0
+    p   := 0
+    while p < len(pairs):
+        if p+1 < len(pairs):
+            (i1, j1) := pairs[p]
+            (i2, j2) := pairs[p+1]
+            prod1 := A[i1] * B[j1]
+            prod2 := A[i2] * B[j2]
+            pair_sum := prod1 + prod2
+
+            if p == 0:
+                sum := pair_sum
+                emit "Ai1_av1*Bj1_bv1=prod1 Ai2_av2*Bj2_bv2=prod2  prod1+prod2=pair_sum  sum=sum"
+            else:
+                prev    := sum
+                new_sum := prev + pair_sum
+                emit "Ai1_av1*Bj1_bv1=prod1 Ai2_av2*Bj2_bv2=prod2  prod1+prod2=pair_sum  prev+pair_sum=new_sum  sum=new_sum"
+                sum := new_sum
+
+            p := p + 2
+        else:
+            (i, j) := pairs[p]
+            prod   := A[i] * B[j]
+
+            if p == 0:
+                sum := prod
+                emit "Ai_av*Bj_bv=prod  sum=prod"
+            else:
+                prev    := sum
+                new_sum := prev + prod
+                emit "Ai_av*Bj_bv=prod  prev+prod=new_sum  sum=new_sum"
+                sum := new_sum
+
+            p := p + 1
+
+    # Apply carry, split into this cell + carry-out
+    total     := sum + carry
+    emit "sum+c{carry}={total}"
+
+    cell      := total mod BASE
+    new_carry := total div BASE
+    out.push(cell)
+    emit "O{k}_{cell pad CHUNK} c{new_carry}"
+    carry := new_carry
+
+# Final cell is just the remaining carry
+out.push(carry)
+emit "k={N+M-1}"
+emit "O{N+M-1}_{carry pad CHUNK}"
+
+emit "RETURN " + tape(out, prefix="O")
+```
+
+## Trace primitives the model emits
+
+| Token            | Meaning                                                               |
+|------------------|-----------------------------------------------------------------------|
+| `START`          | First line of every trace.                                            |
+| `CHUNK=N`        | Declares cell size.                                                   |
+| `tick=N [FIRE]`  | Refresh iteration. The next lines re-print A and B tapes.             |
+| `tick=N [SKIP]`  | Non-refresh iteration. Skip directly to `k=`.                         |
+| `REFRESH` / `END_REFRESH` | Brackets the tape re-print so it can't be confused with output. |
+| `Ai_av`          | Cell i of A has value av (zero-padded to CHUNK digits).               |
+| `Bj_bv`          | Cell j of B has value bv.                                             |
+| `prod1+prod2=ps` | Pair-sum: explicit 2-operand add of this line's two products.         |
+| `prev+ps=ns`     | Running-sum update: prev was the trailing `sum=...` of the line above.|
+| `sum=N`          | Trails every accumulator line. Always the current running sum.        |
+| `sum+cC=T`       | Adds carry-in to the diagonal sum.                                    |
+| `Ok_vc`          | Output cell k = vc. Cell value is `T mod BASE`.                       |
+| `cN`             | New carry = `T div BASE`. Becomes the next iteration's carry-in.      |
+| `RETURN O0_.. O1_.. ...` | Final answer tape, LSB-first.                                 |
+
+## Why each piece exists
+
+- **Cells (not digits)**: At CHUNK=2 the per-cell multiplication is at most
+  99×99=9801 — small enough that the model produces it reliably as one
+  emit. 4× fewer products than digit-level cross.
+- **LSB-first**: input encoding matches tape direction, so no mental
+  reversal during copy. Long tapes used to drift in the middle when the
+  model had to flip indexing.
+- **Pair-grouping**: two products per line gives uniform line shape and
+  halves the number of accumulator lines. Alternating `multiply` and
+  `sum` line types caused attention drift past ~8 products.
+- **Explicit `prod1+prod2=pair_sum` and `prev+pair_sum=new_sum`**: every
+  arithmetic step is a 2-operand equation visible on the same line.
+  No implicit intermediates the model has to compute and remember.
+- **Uniform trailing `sum=N`**: the running sum is always exactly 1 line
+  back, in the same column. Reach distance is constant regardless of
+  trace length.
+- **`tick=N [FIRE|SKIP]` counter**: bounded 0..7 cycle externalized as a
+  token. The model never tracks "is this iteration a refresh" internally —
+  every iteration tells itself.
+- **`REFRESH` re-prints A and B**: bounds the attention distance to any
+  cell value at ~8 k-blocks. Without refresh, distance grows linearly with
+  trace length and the model eventually misreads a cell.
+- **`TAPE_CHUNK=8` per line**: 16+ structurally-identical cells on one
+  line drift in the middle. Wrapping at 8 keeps each tape line within
+  reliable copy range.

--- a/programs/arithmetic-2026-kara-memo/eval.ts
+++ b/programs/arithmetic-2026-kara-memo/eval.ts
@@ -73,7 +73,8 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
   function crossMemoMultiply(
     a: bigint,
     b: bigint,
-    log: (...args: string[]) => void
+    log: (...args: string[]) => void,
+    topLevel: boolean
   ): bigint {
     const A = digitsToTape(a.toString(10))
     const B = digitsToTape(b.toString(10))
@@ -83,7 +84,13 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
     let carry = 0
     const REFRESH_INTERVAL = 8
 
-    log("SUB")
+    // topLevel=true: emit a self-terminating cross-memo trace ending in
+    //   `RETURN O0_.. O1_.. ...` — same shape as the standalone cross-memo
+    //   program. Stays in cell-space so the model never reverses+concats
+    //   16+ cells into a single integer.
+    // topLevel=false: wrap inside SUB / END_SUB so the karatsuba caller
+    //   can frame this as a sub-multiplication and read SUB_RETURN cells.
+    if (!topLevel) log("SUB")
     log(`CHUNK=${chunk}`)
 
     for (let k = 0; k < N + M - 1; k++) {
@@ -155,8 +162,12 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
     log(`k=${N + M - 1}`)
     log(`O${N + M - 1}_${padCell(carry)}`)
 
-    log(`SUB_RETURN ${tapeFmt(out, "O")}`)
-    log("END_SUB")
+    if (topLevel) {
+      log(`RETURN ${tapeFmt(out, "O")}`)
+    } else {
+      log(`SUB_RETURN ${tapeFmt(out, "O")}`)
+      log("END_SUB")
+    }
 
     return tapeToBigInt(out)
   }
@@ -166,13 +177,22 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
   function karatsubaMultiply(
     a: bigint,
     b: bigint,
-    log: (...args: string[]) => void
+    log: (...args: string[]) => void,
+    topLevel: boolean
   ): bigint {
     const N = Math.max(digitsOfBig(a), digitsOfBig(b))
+
+    // Externalize the dispatch as two tokens: N=X KT=Y on one line, then
+    // the comparison result (N<=KT or N>KT) on the next. The next opcode
+    // (SUB for cross-memo, KARATSUBA for the split) follows deterministically
+    // from the comparison. The model never has to remember KT — it reads
+    // it on the line and computes a bounded comparison one step back.
+    log(`N=${N} KT=${karatsubaThreshold}`)
     if (N <= karatsubaThreshold) {
-      // Direct cross-memo, no Karatsuba split
-      return crossMemoMultiply(a, b, log)
+      log(`N<=KT`)
+      return crossMemoMultiply(a, b, log, topLevel)
     }
+    log(`N>KT`)
 
     const half = Math.ceil(N / 2)
     const split = 10n ** BigInt(half)
@@ -184,11 +204,11 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
     log(`B_HI=${bHi} B_LO=${bLo}`)
 
     log(`CALL z0 = A_LO*B_LO = ${aLo}*${bLo}`)
-    const z0 = crossMemoMultiply(aLo, bLo, log)
+    const z0 = karatsubaMultiply(aLo, bLo, log, false)
     log(`RET z0=${z0}`)
 
     log(`CALL z2 = A_HI*B_HI = ${aHi}*${bHi}`)
-    const z2 = crossMemoMultiply(aHi, bHi, log)
+    const z2 = karatsubaMultiply(aHi, bHi, log, false)
     log(`RET z2=${z2}`)
 
     const sx = aHi + aLo, sy = bHi + bLo
@@ -196,7 +216,7 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
     log(`sy = ${bHi}+${bLo} = ${sy}`)
 
     log(`CALL z3 = sx*sy = ${sx}*${sy}`)
-    const z3 = crossMemoMultiply(sx, sy, log)
+    const z3 = karatsubaMultiply(sx, sy, log, false)
     log(`RET z3=${z3}`)
 
     const z3MinusZ2 = z3 - z2
@@ -238,8 +258,15 @@ export function makeMultiply(chunk: number, karatsubaThreshold: number) {
 
     log("START")
     log(`A=${a} B=${b}`)
-    const result = karatsubaMultiply(a, b, log)
-    log(`RETURN ${result}`)
+    const result = karatsubaMultiply(a, b, log, true)
+    // Karatsuba path: result already exists as integer in the trace
+    // (`result = partial+z0 = X+Y = Z`). Emit a terminal RETURN <int>.
+    // Cross-memo path: crossMemoMultiply already emitted `RETURN O0_.. ..`
+    // in cell-form when topLevel=true — no further RETURN needed.
+    const N = Math.max(digitsOfBig(a), digitsOfBig(b))
+    if (N > karatsubaThreshold) {
+      log(`RETURN ${result}`)
+    }
 
     if (result !== a * b) {
       throw new Error(`eval produced wrong product: ${a}*${b} expected=${a*b} got=${result}`)

--- a/programs/arithmetic-2026-kara-memo/index.ts
+++ b/programs/arithmetic-2026-kara-memo/index.ts
@@ -30,9 +30,30 @@ function randomDecimal(digits: number, leadingNonZero = true): string {
 await runProgram(defineProgram({
   name: "arithmetic-2026-kara-memo",
   evaluate: (a, b) => multiply(a, b),
-  // Pass operands as plain decimal strings — Karatsuba and cross-memo
-  // both work on integers, splits derived via division.
-  encode: (a, b) => `A=${a}\nB=${b}`,
+  // Give the model both forms: the integer (Karatsuba splits the operand
+  // by division on the integer) and the cell-aligned LSB-first tape (the
+  // cross-memo sub-block transcribes cells 1:1 from [USER]). Without the
+  // cell form the model has to mentally chunk the integer when entering
+  // a cross-memo block at the top level, which drifts on the first tape
+  // copy. Same TAPE_CHUNK=4 wrapping as cross-memo standalone.
+  encode: (a, b) => {
+    const TAPE_CHUNK = 4
+    const cellEncode = (s: string): string => {
+      const pad = s.length % CHUNK === 0 ? 0 : CHUNK - (s.length % CHUNK)
+      const padded = "0".repeat(pad) + s
+      const cells: string[] = []
+      for (let i = padded.length; i > 0; i -= CHUNK) {
+        cells.push(padded.slice(i - CHUNK, i))
+      }
+      const labeled = cells.map((v, i) => `${i}:${v}`)
+      const lines: string[] = []
+      for (let i = 0; i < labeled.length; i += TAPE_CHUNK) {
+        lines.push(labeled.slice(i, i + TAPE_CHUNK).join(" "))
+      }
+      return lines.join("\n")
+    }
+    return `A=${a}\n${cellEncode(a)}\nB=${b}\n${cellEncode(b)}`
+  },
   display: (arg) => BigInt(arg).toLocaleString("en-US"),
   trainingInputs: [
     // Sub-threshold: triggers pure cross-memo path (no Karatsuba).

--- a/src/models/anthropic.ts
+++ b/src/models/anthropic.ts
@@ -18,67 +18,66 @@ export async function testWithClaude({
 }: ClaudeTestOptions): Promise<TestResult> {
   let responseCount = 0
   let runUsage = zeroUsage()
+  const chunkUsages: ReturnType<typeof summarizeUsage>[] = []
+
+  // Rolling prefill: every continuation sends exactly
+  //   { system (cached), messages: [...initial, { assistant: lastChunk }] }
+  // where lastChunk is the previous call's output (truncated to last
+  // complete line). No cacheControl on messages — only the system has a
+  // breakpoint. The trace itself contains enough state (REFRESH operands,
+  // running carry/sum) to continue from the last chunk alone; earlier
+  // chunks are not re-sent. Full trace is reassembled client-side for
+  // the final return value.
+  let lastChunk = ""
+  let fullTrace = ""
+
+  // Keep system byte-stable across continuations so the breakpoint stays
+  // valid. Optionally append a BEGIN RESPONSE WITH instruction on the
+  // first call only; the instruction is encoded once and never mutated.
+  const effectiveSystem = startToken && system
+    ? `${system}\n---\nBEGIN RESPONSE WITH: ${startToken}\n`
+    : system
+
+  const systemMessage = effectiveSystem
+    ? {
+      role: "system" as const,
+      content: effectiveSystem,
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" as const } },
+      },
+    }
+    : undefined
 
   while (true) {
     console.log()
     console.log(chalk.bold(chalk.yellow(`Response ${responseCount + 1}:`)))
     console.log()
 
-    const assistantMessages = messages.filter(({ role }) => role === "assistant")
+    // Opus 4.6+ rejects assistant-terminal prefill ("conversation must end
+    // with a user message"). So on continuation we send the last chunk as
+    // an assistant turn and append a user CONTINUE prompt. The lastChunk
+    // replaces (not appends) — messages never grow beyond 3 entries.
+    const callMessages = lastChunk
+      ? [
+        ...messages,
+        { role: "assistant" as const, content: lastChunk },
+        { role: "user" as const, content: "CONTINUE" },
+      ]
+      : messages
 
-    /**
-     * Select last {responseCount} assistant messages.
-     */
-    const priorContent =
-      assistantMessages
-        .slice(assistantMessages.length - responseCount)
-        .map(({ content }) =>
-          typeof content === "string"
-            ? content
-            : content
-              .map((part) => (part.type === "text" ? part.text : ""))
-              .join("")
-        )
-        .join("")
-
-    /**
-     * Keep the system content byte-stable across continuations so the
-     * cache_control marker stays valid. We *don't* drop the BEGIN RESPONSE
-     * WITH instruction on iter > 0 the way we used to — that would mutate
-     * the system content between iterations and bust the cache.
-     */
-    const effectiveSystem = startToken && system
-      ? `${system}\n---\nBEGIN RESPONSE WITH: ${startToken}\n`
-      : system
-
-    let output = priorContent
-
-    // Pass the training tape as a SystemModelMessage with an explicit
-    // anthropic cache_control marker. The top-level system: field accepts
-    // string | SystemModelMessage | SystemModelMessage[], so we can attach
-    // providerOptions without putting it inside `messages` (which would
-    // trigger the SDK's prompt-injection warning).
-    const systemMessage = effectiveSystem
-      ? {
-        role: "system" as const,
-        content: effectiveSystem,
-        providerOptions: {
-          anthropic: { cacheControl: { type: "ephemeral" as const } },
-        },
-      }
-      : undefined
+    // `output` tracks the FULL trace client-side (for the rolling solution
+    // check, which compares the trace from START). The API only ever sees
+    // `lastChunk` as the prefill — never the full trace.
+    let output = fullTrace
 
     const result = streamText({
       model,
-      messages,
+      messages: callMessages,
       ...(systemMessage && { system: systemMessage }),
       maxOutputTokens: max_tokens || 4096,
       temperature,
       providerOptions: {
-        gateway: { caching: "auto" },
-        anthropic: {
-          thinking: { type: "disabled" },
-        },
+        anthropic: { thinking: { type: "disabled" } },
       },
     })
 
@@ -109,26 +108,16 @@ export async function testWithClaude({
 
     const chunkUsage = summarizeUsage(usage, providerMetadata)
     runUsage = addUsage(runUsage, chunkUsage)
+    chunkUsages.push(chunkUsage)
 
     if (overflow) {
-      /**
-       * Drop the last line from an incomplete response.
-       */
+      // Drop the last (incomplete) line; everything before it is a clean
+      // suffix of the trace. Replace (not append) the prefill — the model
+      // continues from just this chunk. The full trace stays on the client
+      // for solution checking and the final return value.
       const completed = text.split("\n").slice(0, -1).join("\n")
-      // Mark the assistant continuation with cacheControl so the next call
-      // can read its prior partial response from cache instead of
-      // re-processing it. Combined with the stable system above, the entire
-      // prefix prior to "CONTINUE" stays cache-resident.
-      messages.push(
-        {
-          role: "assistant",
-          content: `${completed}\n`,
-          providerOptions: {
-            anthropic: { cacheControl: { type: "ephemeral" as const } },
-          },
-        },
-        { role: "user", content: "CONTINUE" }
-      )
+      lastChunk = `${completed}\n`
+      fullTrace += lastChunk
 
       console.log("\n")
       console.log(chalk.gray("Continuing response."))
@@ -142,8 +131,8 @@ export async function testWithClaude({
 
     return {
       pass: true,
-      text,
-      metadata: { finishReason, usage: runUsage },
+      text: fullTrace + text,
+      metadata: { finishReason, usage: runUsage, chunks: chunkUsages },
     }
   }
 }

--- a/src/models/cache.test.ts
+++ b/src/models/cache.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "bun:test"
+import { testWithClaude } from "./anthropic"
+import type { UsageSummary } from "./usage"
+
+// Live test: run the same trivial "say hello" program 10 times in a row.
+// First call writes the cached system; subsequent calls read it back.
+// This verifies cross-invocation cache hit behavior.
+
+const hasKey =
+  !!process.env.AI_GATEWAY_API_KEY ||
+  !!process.env.AI_GATEWAY_KEY ||
+  !!process.env.VERCEL_OIDC_TOKEN
+
+if (process.env.AI_GATEWAY_KEY && !process.env.AI_GATEWAY_API_KEY) {
+  process.env.AI_GATEWAY_API_KEY = process.env.AI_GATEWAY_KEY
+}
+
+const live = hasKey ? test : test.skip
+
+// Pad the system above Anthropic's ~1024-token minimum cacheable size.
+const padding = "Procedurally output exactly what is asked. ".repeat(800)
+const SYSTEM = `${padding}\nProgram: when the user says "go", reply with exactly the single word "hello" and nothing else.`
+
+live(
+  "10 runs share one cache write; rest read from cache",
+  async () => {
+    const runs: UsageSummary[] = []
+
+    for (let i = 0; i < 3; i++) {
+      const result = await testWithClaude({
+        system: SYSTEM,
+        messages: [{ role: "user", content: "go" }],
+        max_tokens: 16,
+        model: "anthropic/claude-opus-4.6",
+        temperature: 0,
+        solution: "hello",
+        startToken: null,
+        main: true,
+      })
+
+      expect(result.pass).toBe(true)
+      const meta = result.metadata as { chunks: UsageSummary[] }
+      runs.push(meta.chunks[0])
+    }
+
+    console.log("per-run usage:")
+    for (const [i, u] of runs.entries()) {
+      console.log(`  run ${i + 1}: write=${u.cacheWriteTokens} read=${u.cacheReadTokens} in=${u.inputTokens} out=${u.outputTokens}`)
+    }
+
+    // At most ONE run can be a cold cache write (the first, if the
+    // ephemeral cache wasn't warmed by a prior test). Every other run
+    // must hit cache and do no significant re-writing.
+    const writes = runs.filter(u => u.cacheWriteTokens > 50).length
+    const reads = runs.filter(u => u.cacheReadTokens > 500).length
+    expect(writes).toBeLessThanOrEqual(1)
+    expect(reads).toBeGreaterThanOrEqual(runs.length - 1)
+  },
+  180_000,
+)

--- a/src/models/usage.test.ts
+++ b/src/models/usage.test.ts
@@ -224,16 +224,19 @@ describe("printUsage", () => {
 
     printUsage("run 1", usage, usage)
 
-    // Two calls: leading blank console.log() (separator from streamed output),
-    // then the actual usage summary line.
-    expect(spy).toHaveBeenCalledTimes(2)
+    // Three calls: leading blank console.log() (separator from streamed
+    // output), per-run summary line, cumulative summary line.
+    expect(spy).toHaveBeenCalledTimes(3)
 
-    // Reconstruct what was logged in the summary line — chalk wraps in ANSI codes
-    const logged = spy.mock.calls[1].join(" ")
-    expect(logged).toContain("run 1")
-    expect(logged).toContain("in=")
-    expect(logged).toContain("out=")
-    expect(logged).toContain("$")
+    const runLine = spy.mock.calls[1].join(" ")
+    const cumLine = spy.mock.calls[2].join(" ")
+    expect(runLine).toContain("run 1")
+    expect(runLine).toContain("in=")
+    expect(runLine).toContain("out=")
+    expect(runLine).toContain("$")
+    expect(cumLine).toContain("cum")
+    expect(cumLine).toContain("in=")
+    expect(cumLine).toContain("out=")
 
     spy.mockRestore()
   })

--- a/src/models/usage.ts
+++ b/src/models/usage.ts
@@ -73,21 +73,22 @@ export const zeroUsage = (): UsageSummary => ({ ...ZERO })
 
 const usd = (n: number) => `$${n.toFixed(4)}`
 
-export function printUsage(label: string, run: UsageSummary, total: UsageSummary) {
-  const tokens = `in=${longFormat(run.inputTokens)} out=${longFormat(run.outputTokens)}`
+function fmtTokens(u: UsageSummary): string {
   const cache =
-    run.cacheReadTokens || run.cacheWriteTokens
-      ? ` cache(read=${longFormat(run.cacheReadTokens)} write=${longFormat(run.cacheWriteTokens)})`
+    u.cacheReadTokens || u.cacheWriteTokens
+      ? ` cache(read=${longFormat(u.cacheReadTokens)} write=${longFormat(u.cacheWriteTokens)})`
       : ""
-  const reasoning = run.reasoningTokens
-    ? ` reasoning=${longFormat(run.reasoningTokens)}`
+  const reasoning = u.reasoningTokens
+    ? ` reasoning=${longFormat(u.reasoningTokens)}`
     : ""
-  const runCost = run.cost !== undefined ? ` ${usd(run.cost)}` : ""
-  const totalCost =
-    total.cost !== undefined ? ` (cum ${usd(total.cost)})` : ""
+  const cost = u.cost !== undefined ? ` ${usd(u.cost)}` : ""
+  return `in=${longFormat(u.inputTokens)} out=${longFormat(u.outputTokens)}${cache}${reasoning}${cost}`
+}
 
+export function printUsage(label: string, run: UsageSummary, total: UsageSummary) {
   // Leading newline: the model's streamed RETURN line above doesn't end in \n,
   // so the per-run summary would otherwise collide with it.
   console.log()
-  console.log(chalk.gray(`[${label}] ${tokens}${cache}${reasoning}${runCost}${totalCost}`))
+  console.log(chalk.gray(`[${label}] ${fmtTokens(run)}`))
+  console.log(chalk.gray(`[cum]     ${fmtTokens(total)}`))
 }


### PR DESCRIPTION
## Summary
- kara-memo: externalize dispatch (`N=X KT=Y` / `N<=KT|N>KT`), recurse through unified dispatcher, top-level cross-memo path ends in cell-form RETURN, cell-aligned LSB-first input encoding. 8×8 smoke test passes at 100% ($0.056).
- Cache strategy: rolling prefill replaces (not appends) — every continuation sends `{system (cached), [user, assistant: lastChunk, user "CONTINUE"]}`. Single cache breakpoint on system; no more 4-breakpoint cap warnings. Per-chunk usage tracked in `TestResult.metadata.chunks`.
- `printUsage` now shows cumulative line for input/output/cache/cost.
- `src/models/cache.test.ts`: live test verifying cross-invocation cache hit pattern (1 write + N reads).
- `programs/arithmetic-2026-cross-memo/pseudocode.md`: algorithm trace reference.

## Test plan
- [x] `bun test src/models/` — 36 pass.
- [x] kara-memo 8×8 chunk=2: 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)